### PR TITLE
added condition for filtering when getting quotes from api

### DIFF
--- a/stock-tracker-app/src/main/java/data_access/APIDataAccessObject.java
+++ b/stock-tracker-app/src/main/java/data_access/APIDataAccessObject.java
@@ -64,7 +64,7 @@ public class APIDataAccessObject {
                 while(fields.hasNext()) {
                     Map.Entry<String, JsonNode> entry = fields.next();
                     Date date = new SimpleDateFormat("yyyy-MM-dd").parse(entry.getKey());
-                    if (date.after(startDate) && date.before(endDate)) {
+                    if ((date.after(startDate) || date.equals(startDate)) && (date.before(endDate) || date.equals(endDate))) {
                         double price = entry.getValue().get("4. close").asDouble();
                         quotes.put(date, price);
                     }

--- a/stock-tracker-app/src/main/java/data_access/APIDataAccessObject.java
+++ b/stock-tracker-app/src/main/java/data_access/APIDataAccessObject.java
@@ -64,8 +64,10 @@ public class APIDataAccessObject {
                 while(fields.hasNext()) {
                     Map.Entry<String, JsonNode> entry = fields.next();
                     Date date = new SimpleDateFormat("yyyy-MM-dd").parse(entry.getKey());
-                    double price = entry.getValue().get("4. close").asDouble();
-                    quotes.put(date, price);
+                    if (date.after(startDate) && date.before(endDate)) {
+                        double price = entry.getValue().get("4. close").asDouble();
+                        quotes.put(date, price);
+                    }
                 }
             } catch (IOException | InterruptedException | ParseException e) {
                 e.printStackTrace(); // TODO: handle exception

--- a/stock-tracker-app/src/test/java/data_access/APIDataAccessObjectTest.java
+++ b/stock-tracker-app/src/test/java/data_access/APIDataAccessObjectTest.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Date;
 import java.util.Map;
+import java.util.HashMap;
 import java.text.SimpleDateFormat;
 
 import data_access.APIDataAccessObject;
@@ -24,8 +25,10 @@ public class APIDataAccessObjectTest {
     public void testGetHistoricalQuotes() {
         setUp();
         String symbol = "AAPL";
-        Date startDate = new Date(2023, 11, 1);
-        Date endDate = new Date(2023, 11, 13);
+
+        // November 1st, 2023 to November 5th, 2023
+        Date startDate = new Date(123, 10, 1);
+        Date endDate = new Date(123, 10, 5);
 
         Map<Date, Double> historicalQuotes = DAO.getHistoricalQuotes(symbol, startDate, endDate);
 
@@ -35,16 +38,15 @@ public class APIDataAccessObjectTest {
         for (Map.Entry<Date, Double> entry : historicalQuotes.entrySet()) {
             System.out.println("Date: " + entry.getKey() + " Price: " + entry.getValue());
         }
-//        Tried date filtering here but not working.
-//        String dateString = "Mon Jul 14 00:00:00 EDT 2003";
-//        SimpleDateFormat dateFormat = new SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy");
-//        try {
-//            Date date = dateFormat.parse(dateString);
-//            System.out.println(historicalQuotes.get(dateFormat));
-//        } catch (Exception e) {
-//            System.out.println("Not working yet.");
-//        }
-        System.out.println("Test1 passed.");
+
+        // Manual entered these from values on yahoo finance
+        assert(historicalQuotes.get(new Date(123, 10, 1)) == 173.97);
+        assert(historicalQuotes.get(new Date(123, 10, 2)) == 177.57);
+        assert(historicalQuotes.get(new Date(123, 10, 3)) == 176.65);
+
+        // These are weekends, so there should be no data
+        assert(historicalQuotes.get(new Date(123, 10, 4)) == null);
+        assert(historicalQuotes.get(new Date(123, 10, 5)) == null);
     }
 
     @Test
@@ -55,8 +57,10 @@ public class APIDataAccessObjectTest {
          */
         setUp();
         String symbol = "AAPL";
-        Date startDate = new Date(2023, 10, 3);
-        Date endDate = new Date(2023, 10, 1);
+
+        // November 3rd, 2023 to November 1st, 2023
+        Date startDate = new Date(123, 10, 3);
+        Date endDate = new Date(123, 10, 1);
         try {
             Map<Date, Double> historicalQuotes = DAO.getHistoricalQuotes(symbol, startDate, endDate);
             System.out.println("Test2 NOT passed.");

--- a/stock-tracker-app/src/test/java/data_access/APIDataAccessObjectTest.java
+++ b/stock-tracker-app/src/test/java/data_access/APIDataAccessObjectTest.java
@@ -53,7 +53,7 @@ public class APIDataAccessObjectTest {
     public void testGetInvalidHistoricalQuotes() {
         /**
          * Test 2
-         * Provided input startDate < endDate.
+         * Provided input startDate is after endDate.
          */
         setUp();
         String symbol = "AAPL";
@@ -73,12 +73,14 @@ public class APIDataAccessObjectTest {
     public void testGetFutureHistoricalQuotes() {
         /**
          * Test 3
-         * Provided input endDate > today.
+         * Provided input endDate is after today.
          */
         setUp();
         String symbol = "AAPL";
-        Date startDate = new Date(2025, 1, 1);
-        Date endDate = new Date(2025, 1, 5);
+
+        // January 1st, 2025 to January 5th, 2025
+        Date startDate = new Date(125, 0, 1);
+        Date endDate = new Date(125, 0, 5);
         try {
             Map<Date, Double> historicalQuotes = DAO.getHistoricalQuotes(symbol, startDate, endDate);
 //            LocalDate localDate = LocalDate.now();


### PR DESCRIPTION
- added condition in APIDataAccessObject.getHistoricalQuotes() to filter for date range.
- we should think about not using deprecated methods in the Date class but I will leave it for now
- added date range filter to testGetHistoricalQutotes()
- we need to make sure the other tests actually have assert statements