### PR TITLE
Using TreeMap instead of HashMap for historical quotes data

### DIFF
--- a/stock-tracker-app/src/main/java/data_access/APIDataAccessObject.java
+++ b/stock-tracker-app/src/main/java/data_access/APIDataAccessObject.java
@@ -17,7 +17,7 @@ import java.time.ZoneId;
 import java.util.Date;
 import java.text.ParseException;
 import java.util.TreeMap;
-import java.util.Map
+import java.util.Map;
 import java.util.Iterator;
 import java.time.LocalDate;
 import java.io.File;

--- a/stock-tracker-app/src/main/java/data_access/APIDataAccessObject.java
+++ b/stock-tracker-app/src/main/java/data_access/APIDataAccessObject.java
@@ -16,9 +16,9 @@ import java.text.SimpleDateFormat;
 import java.time.ZoneId;
 import java.util.Date;
 import java.text.ParseException;
-import java.util.HashMap;
+import java.util.TreeMap;
+import java.util.Map
 import java.util.Iterator;
-import java.util.Map;
 import java.time.LocalDate;
 import java.io.File;
 
@@ -55,8 +55,8 @@ public class APIDataAccessObject {
 
         // this method will be used in the real program, but for testing purposes we will use the one below
         // we will have to change the name of this back to getHistoricalQuotes() at some point
-        public HashMap<Date, Double> getHistoricalQuotesReal(String symbol, Date startDate, Date endDate) {
-            HashMap<Date, Double> quotes = new HashMap<>();
+        public TreeMap<Date, Double> getHistoricalQuotesReal(String symbol, Date startDate, Date endDate) {
+            TreeMap<Date, Double> quotes = new TreeMap<>();
             try {
                 String urlString = buildApiUrl(symbol, startDate, endDate);
                 HttpRequest request = HttpRequest.newBuilder()
@@ -86,8 +86,8 @@ public class APIDataAccessObject {
 
         // this method is for testing purposes only, it reads from a local file instead of making an API call
         // the real is above and will have to have its name changed to getHistoricalQuotes
-        public HashMap<Date, Double> getHistoricalQuotes(String symbol, Date startDate, Date endDate) {
-            HashMap<Date, Double> quotes = new HashMap<>();
+        public TreeMap<Date, Double> getHistoricalQuotes(String symbol, Date startDate, Date endDate) {
+            TreeMap<Date, Double> quotes = new TreeMap<>();
             try {
                 String urlString = buildApiUrl(symbol, startDate, endDate);
                 HttpRequest request = HttpRequest.newBuilder()
@@ -125,7 +125,7 @@ public class APIDataAccessObject {
 
 
         // gets all historical quotes for a given symbol
-        public HashMap<Date, Double> getHistoricalQuotes(String symbol) {
+        public TreeMap<Date, Double> getHistoricalQuotes(String symbol) {
             return getHistoricalQuotes(symbol, new Date(0, 0, 1), new Date(Integer.MAX_VALUE, 11, 31));
         }
 

--- a/stock-tracker-app/src/main/java/entity/TradeTransaction.java
+++ b/stock-tracker-app/src/main/java/entity/TradeTransaction.java
@@ -29,9 +29,4 @@ public class TradeTransaction extends Transaction {
     public double getAmountOut() {
         return amountOut;
     }
-
-
-    private void trade() {
-        // #TODO
-    }
 }

--- a/stock-tracker-app/src/main/java/entity/Tradeable.java
+++ b/stock-tracker-app/src/main/java/entity/Tradeable.java
@@ -32,6 +32,12 @@ public class Tradeable {
     }
 
     public double getCurrentPrice() {
-        return this.priceHistory.get(LocalDate.now());
+        // checks the last 365 days for a price
+        for (int i = 0; i < 365; i++) {
+            if (priceHistory.get(LocalDate.now().minusDays(i)) != null) {
+                return priceHistory.get(LocalDate.now().minusDays(i));
+            }
+        }
+        throw new RuntimeException("No price history found in last year for " + this.symbol);
     }
 }

--- a/stock-tracker-app/src/main/java/entity/Tradeable.java
+++ b/stock-tracker-app/src/main/java/entity/Tradeable.java
@@ -1,18 +1,18 @@
 package entity;
 
 import java.util.Date;
-import java.util.HashMap;
+import java.util.TreeMap;
 import java.time.LocalDate;
 
 public class Tradeable {
     private String name; // e.g. "Apple Inc."
     private String symbol; // e.g. "AAPL"
-    private HashMap<Date, Double> priceHistory; // price history in USD
+    private TreeMap<Date, Double> priceHistory; // price history in USD
 
     public Tradeable(String name, String symbol) {
         this.name = name;
         this.symbol = symbol;
-        this.priceHistory = new HashMap<>();
+        this.priceHistory = new TreeMap<>();
     }
 
     public String getName() {
@@ -23,21 +23,18 @@ public class Tradeable {
         return symbol;
     }
 
-    public HashMap<Date, Double> getPriceHistory() {
+    public TreeMap<Date, Double> getPriceHistory() {
         return priceHistory;
     }
 
-    public void setPriceHistory(HashMap<Date, Double> priceHistory) {
+    public void setPriceHistory(TreeMap<Date, Double> priceHistory) {
         this.priceHistory = priceHistory;
     }
 
     public double getCurrentPrice() {
-        // checks the last 365 days for a price
-        for (int i = 0; i < 365; i++) {
-            if (priceHistory.get(LocalDate.now().minusDays(i)) != null) {
-                return priceHistory.get(LocalDate.now().minusDays(i));
-            }
+        if (priceHistory.size() == 0) {
+            throw new RuntimeException("No price history found for " + this.symbol);
         }
-        throw new RuntimeException("No price history found in last year for " + this.symbol);
+        return priceHistory.lastEntry().getValue();
     }
 }

--- a/stock-tracker-app/src/test/java/data_access/APIDataAccessObjectTest.java
+++ b/stock-tracker-app/src/test/java/data_access/APIDataAccessObjectTest.java
@@ -4,7 +4,7 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Date;
 import java.util.Map;
-import java.util.HashMap;
+import java.util.TreeMap;
 import java.text.SimpleDateFormat;
 
 import data_access.APIDataAccessObject;


### PR DESCRIPTION
- Tradeables now store their historical price data in TreeMaps
- We can now easily reference the most recent element
- Implemented Tradeable.getCurrentPrice() very simply now