### PR TITLE
Forex quotes and default currency conversion

### DIFF
--- a/stock-tracker-app/src/main/java/data_access/APIDataAccessObject.java
+++ b/stock-tracker-app/src/main/java/data_access/APIDataAccessObject.java
@@ -40,7 +40,9 @@ public class APIDataAccessObject {
         public APIDataAccessObject() {
             this.httpClient = HttpClient.newHttpClient();
             this.objectMapper = new ObjectMapper();
-            this.apiKey = readApiKeyFromFile("key.txt");
+            // we will use demo api calls for now, but we will have to uncomment the line below to use the real api
+            this.apiKey = "demo";
+            // this.apiKey = readApiKeyFromFile("key.txt");
         }
 
         // this method will be used in the real program, but for testing purposes we will use the one below
@@ -151,43 +153,6 @@ public class APIDataAccessObject {
                     }
                 }
             } catch (IOException | InterruptedException | ParseException e) {
-                e.printStackTrace(); // TODO: handle exception
-            }
-            return quotes;
-        }
-
-        // this method is for testing purposes only, it reads from a local file instead of making an API call
-        // the real is above and will have to have its name changed to getHistoricalQuotes
-        public TreeMap<Date, Double> getHistoricalQuotes(String symbol) {
-            TreeMap<Date, Double> quotes = new TreeMap<>();
-            try {
-                String urlString = buildApiUrl(symbol);
-                HttpRequest request = HttpRequest.newBuilder()
-                        .uri(URI.create(urlString))
-                        .build();
-
-                JsonNode root;
-                if (symbol.equals("IBM")) {
-                    String filePath = "test_queries/IBM.json";
-                    ObjectMapper objectMapper = new ObjectMapper();
-                    root = objectMapper.readTree(new File(filePath));
-                }
-                else {
-                    String filePath = "test_queries/SHOP-TO.json";
-                    ObjectMapper objectMapper = new ObjectMapper();
-                    root = objectMapper.readTree(new File(filePath));
-                }
-
-                JsonNode timeSeries = root.get("Time Series (Daily)");
-
-                Iterator<Map.Entry<String, JsonNode>> fields = timeSeries.fields();
-                while(fields.hasNext()) {
-                    Map.Entry<String, JsonNode> entry = fields.next();
-                    Date date = new SimpleDateFormat("yyyy-MM-dd").parse(entry.getKey());
-                    double price = entry.getValue().get("4. close").asDouble();
-                    quotes.put(date, price);
-                }
-            } catch (IOException | ParseException e) {
                 e.printStackTrace(); // TODO: handle exception
             }
             return quotes;

--- a/stock-tracker-app/src/main/java/entity/Portfolio.java
+++ b/stock-tracker-app/src/main/java/entity/Portfolio.java
@@ -3,7 +3,6 @@ package entity;
 import java.util.HashMap;
 import java.util.ArrayList;
 import java.io.Serializable;
-import entity.Currency;
 import entity.Transaction;
 import entity.TradeTransaction;
 import entity.BankingTransaction;
@@ -12,7 +11,7 @@ import entity.Tradeable;
 public class Portfolio implements Serializable {
     private final String name;
 
-    private Currency currency;
+    private Tradeable currency;
 
     private HashMap<Tradeable, Double> holdings;
 
@@ -20,7 +19,7 @@ public class Portfolio implements Serializable {
 
     private final int portfolioId;
 
-    public Portfolio(String name, Currency currency, HashMap<Tradeable, Double> holdings, ArrayList<Transaction> transactions, int portfolioId) {
+    public Portfolio(String name, Tradeable currency, HashMap<Tradeable, Double> holdings, ArrayList<Transaction> transactions, int portfolioId) {
         this.name = name;
         this.currency = currency;
         this.holdings = holdings;
@@ -30,7 +29,7 @@ public class Portfolio implements Serializable {
 
     public Portfolio(String name) {
         this.name = name;
-        this.currency = new Currency("USD");
+        this.currency = new Tradeable("US Dollar", "$USD");
         this.holdings = new HashMap<>();
         this.transactions = new ArrayList<>();
         this.portfolioId = 0;
@@ -40,7 +39,7 @@ public class Portfolio implements Serializable {
         return this.name;
     }
 
-    public Currency getCurrency() {
+    public Tradeable getCurrency() {
         return this.currency;
     }
 

--- a/stock-tracker-app/src/main/java/use_case/update_prices/UpdatePricesInteractor.java
+++ b/stock-tracker-app/src/main/java/use_case/update_prices/UpdatePricesInteractor.java
@@ -23,7 +23,7 @@ public class UpdatePricesInteractor {
         Portfolio portfolio = fileDataAccessObject.getPortfolio(portfolioName);
 
         for(Tradeable holding : portfolio.getHoldings().keySet()) {
-            holding.setPriceHistory(apiDataAccessObject.getHistoricalQuotes(holding.getSymbol()));
+            holding.setPriceHistory(apiDataAccessObject.getHistoricalQuotes(holding.getSymbol(), portfolio.getCurrency().getSymbol()));
         }
 
         fileDataAccessObject.savePortfolio(portfolio);


### PR DESCRIPTION
- added private methods to APIDataAccessObject for handling FOREX
- also handles cases where stock quotes are given in currency that is different from portfolio's default (for example Canadian stocks in a USD porfolio)
- does not handle cases where default currency is not a currency (for measuring gains against cryptos, gold, indexes)